### PR TITLE
CMakeLists.txt: check launch file if testing is on

### DIFF
--- a/imu_transformer/CMakeLists.txt
+++ b/imu_transformer/CMakeLists.txt
@@ -5,7 +5,6 @@ find_package(catkin REQUIRED COMPONENTS
   message_filters
   nodelet
   roscpp
-  roslaunch
   sensor_msgs
   geometry_msgs
   tf2
@@ -31,7 +30,10 @@ target_link_libraries(imu_transformer_nodelet ${catkin_LIBRARIES})
 add_executable(imu_transformer_node src/imu_transformer_node.cpp)
 target_link_libraries(imu_transformer_node ${catkin_LIBRARIES})
 
-roslaunch_add_file_check(launch)
+if(CATKIN_ENABLE_TESTING)
+  find_package(roslaunch REQUIRED)
+  roslaunch_add_file_check(launch)
+endif()
 
 install(TARGETS imu_transformer_node imu_transformer_nodelet
 	RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}


### PR DESCRIPTION
When building with CATKIN_ENABLE_TESTING deactivated, configure
fails with:

| -- Using CATKIN_ENABLE_TESTING: 0
| -- catkin 0.6.14
| -- Using these message generators: gencpp;genlisp;genpy
| CMake Error at /opt/ros/indigo/share/roslaunch/cmake/roslaunch-extras.cmake:35 (catkin_run_tests_target):
|   Unknown CMake command "catkin_run_tests_target".
| Call Stack (most recent call first):
|   CMakeLists.txt:34 (roslaunch_add_file_check)
|
|
| -- Configuring incomplete, errors occurred!

Configure fails as the test command 'catkin_run_tests_target' is
only defined in catkin if CATKIN_ENABLE_TESTING is enabled.
Hence, this commit changes CMakeLists.txt so that the command is
only used if CATKIN_ENABLE_TESTING is enabled.

Signed-off-by: Lukas Bulwahn lukas.bulwahn@oss.bmw-carit.de
