### PR TITLE
update to use non deprecated pluginlib macro

### DIFF
--- a/imu_transformer/src/imu_transformer_nodelet.cpp
+++ b/imu_transformer/src/imu_transformer_nodelet.cpp
@@ -123,4 +123,4 @@ namespace imu_transformer
 
 }
 
-PLUGINLIB_DECLARE_CLASS(imu_transformer, ImuTransformerNodelet, imu_transformer::ImuTransformerNodelet, nodelet::Nodelet);
+PLUGINLIB_EXPORT_CLASS(imu_transformer::ImuTransformerNodelet, nodelet::Nodelet)


### PR DESCRIPTION
These macros, deprecated for now 8 years, will be removed in the next ROS release (ROS Melodic)

This change will allow the code to keep compiling on future ROS versions