### PR TITLE
imu_transformer: Fix transformation of the orientation of IMU

### DIFF
--- a/imu_transformer/CMakeLists.txt
+++ b/imu_transformer/CMakeLists.txt
@@ -16,7 +16,7 @@ find_package(catkin REQUIRED COMPONENTS
 catkin_package(
   INCLUDE_DIRS include
   LIBRARIES imu_transformer_nodelet
-  CATKIN_DEPENDS roscpp message_filters nodelet sensor_msgs tf2 tf2_ros geometry_msgs
+  CATKIN_DEPENDS roscpp message_filters nodelet sensor_msgs tf2 tf2_ros geometry_msgs topic_tools
 )
 
 include_directories(
@@ -33,6 +33,11 @@ target_link_libraries(imu_transformer_node ${catkin_LIBRARIES})
 if(CATKIN_ENABLE_TESTING)
   find_package(roslaunch REQUIRED)
   roslaunch_add_file_check(launch)
+
+  find_package(tf2_geometry_msgs REQUIRED)
+  include_directories(${tf2_geometry_msgs_INCLUDE_DIRS})
+  catkin_add_gtest(test_imu_transforms test/test_imu_transforms.cpp)
+  target_link_libraries(test_imu_transforms ${catkin_LIBRARIES} ${tf2_geometry_msgs_LIBRARIES})
 endif()
 
 install(TARGETS imu_transformer_node imu_transformer_nodelet

--- a/imu_transformer/include/imu_transformer/tf2_sensor_msgs.h
+++ b/imu_transformer/include/imu_transformer/tf2_sensor_msgs.h
@@ -108,7 +108,9 @@ namespace tf2
 
     transformCovariance(imu_in.linear_acceleration_covariance, imu_out.linear_acceleration_covariance, r);
 
-    Eigen::Quaternion<double> orientation = r * Eigen::Quaternion<double>(
+    // Orientation expresses attitude of the new frame_id in a fixed world frame. This is why the transform here applies
+    // in the opposite direction.
+    Eigen::Quaternion<double> orientation = Eigen::Quaternion<double>(
         imu_in.orientation.w, imu_in.orientation.x, imu_in.orientation.y, imu_in.orientation.z) * r.inverse();
 
     imu_out.orientation.w = orientation.w();
@@ -116,7 +118,9 @@ namespace tf2
     imu_out.orientation.y = orientation.y();
     imu_out.orientation.z = orientation.z();
 
-    transformCovariance(imu_in.orientation_covariance, imu_out.orientation_covariance, r);
+    // Orientation is measured relative to the fixed world frame, so it doesn't change when applying a static
+    // transform to the sensor frame.
+    imu_out.orientation_covariance = imu_in.orientation_covariance;
 
   }
 

--- a/imu_transformer/package.xml
+++ b/imu_transformer/package.xml
@@ -29,6 +29,7 @@
   <exec_depend>tf</exec_depend>
 
   <test_depend>roslaunch</test_depend>
+  <test_depend>tf2_geometry_msgs</test_depend>
 
   <export>
     <nodelet plugin="${prefix}/nodelets.xml"/>

--- a/imu_transformer/test/test_imu_transforms.cpp
+++ b/imu_transformer/test/test_imu_transforms.cpp
@@ -1,0 +1,275 @@
+/**
+ * \file
+ * \brief 
+ * \author Martin Pecka
+ * SPDX-License-Identifier: BSD-3-Clause
+ * SPDX-FileCopyrightText: Czech Technical University in Prague
+ */
+
+#include "gtest/gtest.h"
+
+#include <imu_transformer/tf2_sensor_msgs.h>
+#include <sensor_msgs/Imu.h>
+#include <sensor_msgs/MagneticField.h>
+#include <tf2/LinearMath/Quaternion.h>
+#include <tf2_geometry_msgs/tf2_geometry_msgs.h>
+
+void compareCovariances(const boost::array<double, 9>& c1, const boost::array<double, 9>& c2)
+{
+  for (size_t i = 0; i < 9; ++i)
+    EXPECT_NEAR(c1[i], c2[i], 1e-6) << "Wrong value at position " << i;
+}
+
+TEST(Covariance, Transform)
+{
+  boost::array<double, 9> in = {1, 0, 0, 0, 2, 0, 0, 0, 3};
+  boost::array<double, 9> expectedOut = {1, 0, 0, 0, 2, 0, 0, 0, 3};
+  boost::array<double, 9> out{};
+  Eigen::Quaterniond q(1, 0, 0, 0);
+  tf2::transformCovariance(in, out, q);
+  compareCovariances(expectedOut, out);
+  
+  q = Eigen::Quaterniond(Eigen::AngleAxisd(M_PI_2, Eigen::Vector3d(0, 0, 1)));
+  expectedOut = {2, 0, 0, 0, 1, 0, 0, 0, 3};
+  tf2::transformCovariance(in, out, q);
+  compareCovariances(expectedOut, out);
+
+  q = q.inverse();
+  tf2::transformCovariance(in, out, q);
+  compareCovariances(expectedOut, out);
+  
+  q = Eigen::Quaterniond(Eigen::AngleAxisd(M_PI_2, Eigen::Vector3d(1, 0, 0)));
+  expectedOut = {1, 0, 0, 0, 3, 0, 0, 0, 2};
+  tf2::transformCovariance(in, out, q);
+  compareCovariances(expectedOut, out);
+
+  q = q.inverse();
+  tf2::transformCovariance(in, out, q);
+  compareCovariances(expectedOut, out);
+  
+  q = Eigen::Quaterniond(Eigen::AngleAxisd(M_PI_2, Eigen::Vector3d(0, 1, 0)));
+  expectedOut = {3, 0, 0, 0, 2, 0, 0, 0, 1};
+  tf2::transformCovariance(in, out, q);
+  compareCovariances(expectedOut, out);
+  
+  q = q.inverse();
+  tf2::transformCovariance(in, out, q);
+  compareCovariances(expectedOut, out);
+  
+  q = Eigen::Quaterniond(Eigen::AngleAxisd(M_PI_2, Eigen::Vector3d(1, 1, 1)));
+  expectedOut = {2.5, -0.5, 3, 1, 0, -1, -1.5, 2, 0.5};
+  tf2::transformCovariance(in, out, q);
+  compareCovariances(expectedOut, out);
+  
+  q = q.inverse();
+  expectedOut = {1.5, -1, 1, 2, 2, -1.5, -0.5, 3, -0.5};
+  tf2::transformCovariance(in, out, q);
+  compareCovariances(expectedOut, out);
+}
+
+TEST(Imu, GetTimestamp)
+{
+  sensor_msgs::Imu msg;
+  msg.header.stamp.sec = 1;
+  msg.header.stamp.nsec = 2;
+  
+  EXPECT_EQ(msg.header.stamp, tf2::getTimestamp(msg));
+}
+
+TEST(Imu, GetFrameId)
+{
+  sensor_msgs::Imu msg;
+  msg.header.frame_id = "test";
+  
+  EXPECT_EQ(msg.header.frame_id, tf2::getFrameId(msg));
+}
+
+void prepareImuMsg(sensor_msgs::Imu& msg)
+{
+  msg.header.frame_id = "test2";
+  msg.header.stamp.sec = 1;
+  msg.angular_velocity.x = 1;
+  msg.angular_velocity.y = 2;
+  msg.angular_velocity.z = 3;
+  msg.angular_velocity_covariance = {1, 0, 0, 0, 2, 0, 0, 0, 3};
+  msg.linear_acceleration.x = 1;
+  msg.linear_acceleration.y = 2;
+  msg.linear_acceleration.z = 3;
+  msg.linear_acceleration_covariance = {1, 0, 0, 0, 2, 0, 0, 0, 3};
+  msg.orientation.w = 1;
+  msg.orientation_covariance = {1, 0, 0, 0, 2, 0, 0, 0, 3};
+}
+
+void prepareTf(geometry_msgs::TransformStamped& tf)
+{
+  tf.header.frame_id = "test";
+  tf.header.stamp.sec = 1;
+  tf.child_frame_id = "test2";
+  tf.transform.translation.x = 1e6;
+  tf.transform.translation.y = 2e6;
+  tf.transform.translation.z = -3e6;
+  tf.transform.rotation.w = 1;
+}
+
+TEST(Imu, DoTransformYaw)
+{
+  // Q = +90 degrees yaw
+  
+  sensor_msgs::Imu msg;
+  prepareImuMsg(msg);
+  
+  geometry_msgs::TransformStamped tf;
+  prepareTf(tf);
+
+  tf2::Quaternion q;
+  q.setRPY(0, 0, M_PI_2);
+  tf2::convert(q, tf.transform.rotation);
+  
+  sensor_msgs::Imu out;
+  tf2::doTransform(msg, out, tf);
+  
+  tf2::Quaternion rot;
+  
+  EXPECT_EQ("test", out.header.frame_id);
+  EXPECT_EQ(msg.header.stamp, out.header.stamp);
+  EXPECT_NEAR(-msg.angular_velocity.y, out.angular_velocity.x, 1e-6);
+  EXPECT_NEAR(msg.angular_velocity.x, out.angular_velocity.y, 1e-6);
+  EXPECT_NEAR(msg.angular_velocity.z, out.angular_velocity.z, 1e-6);
+  EXPECT_NEAR(-msg.linear_acceleration.y, out.linear_acceleration.x, 1e-6);
+  EXPECT_NEAR(msg.linear_acceleration.x, out.linear_acceleration.y, 1e-6);
+  EXPECT_NEAR(msg.linear_acceleration.z, out.linear_acceleration.z, 1e-6);
+  // Transforming orientation means expressing the attitude of the new frame in the same world frame (i.e. you have
+  // data in imu frame and want to ask what is the world-referenced orientation of the base_link frame that is attached
+  // to this IMU). This is why the orientation change goes the other way than the transform.
+  tf2::convert(out.orientation, rot);
+  EXPECT_NEAR(0, rot.angleShortestPath(q.inverse()), 1e-6);
+
+  compareCovariances({2, 0, 0, 0, 1, 0, 0, 0, 3}, out.angular_velocity_covariance);
+  compareCovariances({2, 0, 0, 0, 1, 0, 0, 0, 3}, out.linear_acceleration_covariance);
+  // Orientation covariance stays as it is measured regarding the fixed world frame 
+  compareCovariances(msg.orientation_covariance, out.orientation_covariance);
+}
+
+TEST(Imu, DoTransformEnuNed)
+{
+  // Q = ENU->NED transform
+  
+  sensor_msgs::Imu msg;
+  prepareImuMsg(msg);
+  
+  geometry_msgs::TransformStamped tf;
+  prepareTf(tf);
+
+  tf2::Quaternion q;
+  q.setRPY(M_PI, 0, M_PI_2);
+  tf2::convert(q, tf.transform.rotation);
+  
+  sensor_msgs::Imu out;
+  tf2::doTransform(msg, out, tf);
+  
+  tf2::Quaternion rot;
+  
+  EXPECT_EQ("test", out.header.frame_id);
+  EXPECT_EQ(msg.header.stamp, out.header.stamp);
+  EXPECT_NEAR(msg.angular_velocity.y, out.angular_velocity.x, 1e-6);
+  EXPECT_NEAR(msg.angular_velocity.x, out.angular_velocity.y, 1e-6);
+  EXPECT_NEAR(-msg.angular_velocity.z, out.angular_velocity.z, 1e-6);
+  EXPECT_NEAR(msg.linear_acceleration.y, out.linear_acceleration.x, 1e-6);
+  EXPECT_NEAR(msg.linear_acceleration.x, out.linear_acceleration.y, 1e-6);
+  EXPECT_NEAR(-msg.linear_acceleration.z, out.linear_acceleration.z, 1e-6);
+  // Transforming orientation means expressing the attitude of the new frame in the same world frame (i.e. you have
+  // data in imu frame and want to ask what is the world-referenced orientation of the base_link frame that is attached
+  // to this IMU). This is why the orientation change goes the other way than the transform.
+  tf2::convert(out.orientation, rot);
+  EXPECT_NEAR(0, rot.angleShortestPath(q.inverse()), 1e-6);
+
+  compareCovariances({2, 0, 0, 0, 1, 0, 0, 0, 3}, out.angular_velocity_covariance);
+  compareCovariances({2, 0, 0, 0, 1, 0, 0, 0, 3}, out.linear_acceleration_covariance);
+  // Orientation covariance stays as it is measured regarding the fixed world frame 
+  compareCovariances(msg.orientation_covariance, out.orientation_covariance);
+}
+
+TEST(Mag, GetTimestamp)
+{
+  sensor_msgs::MagneticField msg;
+  msg.header.stamp.sec = 1;
+  msg.header.stamp.nsec = 2;
+
+  EXPECT_EQ(msg.header.stamp, tf2::getTimestamp(msg));
+}
+
+TEST(Mag, GetFrameId)
+{
+  sensor_msgs::MagneticField msg;
+  msg.header.frame_id = "test";
+
+  EXPECT_EQ(msg.header.frame_id, tf2::getFrameId(msg));
+}
+
+void prepareMagMsg(sensor_msgs::MagneticField& msg)
+{
+  msg.header.frame_id = "test2";
+  msg.header.stamp.sec = 1;
+  msg.magnetic_field.x = 1;
+  msg.magnetic_field.y = 2;
+  msg.magnetic_field.z = 3;
+  msg.magnetic_field_covariance = {1, 0, 0, 0, 2, 0, 0, 0, 3};
+}
+
+TEST(Mag, DoTransformYaw)
+{
+  // Q = +90 degrees yaw
+
+  sensor_msgs::MagneticField msg;
+  prepareMagMsg(msg);
+
+  geometry_msgs::TransformStamped tf;
+  prepareTf(tf);
+
+  tf2::Quaternion q;
+  q.setRPY(0, 0, M_PI_2);
+  tf2::convert(q, tf.transform.rotation);
+
+  sensor_msgs::MagneticField out;
+  tf2::doTransform(msg, out, tf);
+
+  EXPECT_EQ("test", out.header.frame_id);
+  EXPECT_EQ(msg.header.stamp, out.header.stamp);
+  EXPECT_NEAR(-msg.magnetic_field.y, out.magnetic_field.x, 1e-6);
+  EXPECT_NEAR(msg.magnetic_field.x, out.magnetic_field.y, 1e-6);
+  EXPECT_NEAR(msg.magnetic_field.z, out.magnetic_field.z, 1e-6);
+
+  compareCovariances({2, 0, 0, 0, 1, 0, 0, 0, 3}, out.magnetic_field_covariance);
+}
+
+TEST(Mag, DoTransformEnuNed)
+{
+  // Q = ENU->NED transform
+
+  sensor_msgs::MagneticField msg;
+  prepareMagMsg(msg);
+
+  geometry_msgs::TransformStamped tf;
+  prepareTf(tf);
+
+  tf2::Quaternion q;
+  q.setRPY(M_PI, 0, M_PI_2);
+  tf2::convert(q, tf.transform.rotation);
+
+  sensor_msgs::MagneticField out;
+  tf2::doTransform(msg, out, tf);
+
+  EXPECT_EQ("test", out.header.frame_id);
+  EXPECT_EQ(msg.header.stamp, out.header.stamp);
+  EXPECT_NEAR(msg.magnetic_field.y, out.magnetic_field.x, 1e-6);
+  EXPECT_NEAR(msg.magnetic_field.x, out.magnetic_field.y, 1e-6);
+  EXPECT_NEAR(-msg.magnetic_field.z, out.magnetic_field.z, 1e-6);
+
+  compareCovariances({2, 0, 0, 0, 1, 0, 0, 0, 3}, out.magnetic_field_covariance);
+}
+
+int main(int argc, char **argv)
+{
+  testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}

--- a/imu_transformer/test/test_imu_transforms.launch
+++ b/imu_transformer/test/test_imu_transforms.launch
@@ -1,0 +1,22 @@
+<launch>
+    <!-- This launch file serves as a visual confirmation that the transformation of IMU orientation works as expected.
+     A world frame is set up, in which imu_link is placed with 90 deg yaw. Then, imu_link_ned is set up which corresponds
+     to the same link but after applying ENU-NED frame conversion. Frame world is set as fixed frame, and both IMU
+     visualizers in the rviz view are set to display orientation regarding the fixed frame (which is the world frame).
+     So in this case, the axes displayed by the rviz IMU visualizers should match the imu_link and imu_link_ned
+     axes visualized from TF. Please note that the frames have non-zero translation in rviz so that it is easier to
+     distinguish them. But the translation has no effect on the computations, since IMU data are only transformed by
+     rotation.
+     
+     Another confirmation of the correctness of the implementation can be got when running "tf_echo world imu_link_ned".
+     The orientation in the output of this command should match the orientation that is output in imu_out/data - which
+     should be orientation of the imu_link_ned frame in the world frame. -->
+    <arg name="rviz" default="true" />
+    <node name="tf1" pkg="tf2_ros" type="static_transform_publisher" args="0.7 0 0 1.5708 0 0 world imu_link" />
+    <node name="tf2" pkg="tf2_ros" type="static_transform_publisher" args="0.5 0.5 0 1.5708 0 3.1416 imu_link imu_link_ned" />
+    <node name="transformer" pkg="imu_transformer" type="imu_transformer_node">
+        <param name="target_frame" value="imu_link_ned" />
+    </node>
+    <node name="msg" pkg="rostopic" type="rostopic" args="pub -r10 /imu_in/data sensor_msgs/Imu &quot;{header: {frame_id: 'imu_link'}, orientation: {z: 0.707, w: 0.707}}&quot;" />
+    <node name="rviz" pkg="rviz" type="rviz" args="-d $(dirname)/test_imu_transforms.rviz" if="$(arg rviz)" />
+</launch>

--- a/imu_transformer/test/test_imu_transforms.rviz
+++ b/imu_transformer/test/test_imu_transforms.rviz
@@ -1,0 +1,248 @@
+Panels:
+  - Class: rviz/Displays
+    Help Height: 78
+    Name: Displays
+    Property Tree Widget:
+      Expanded:
+        - /Global Options1
+        - /imu_link1
+        - /imu_link1/TF1/Frames1
+        - /imu_link_ned1
+        - /imu_link_ned1/TF1/Frames1
+        - /imu_link_ned1/Imu1/Axes properties1
+        - /World TF1/Frames1
+      Splitter Ratio: 0.5
+    Tree Height: 656
+  - Class: rviz/Selection
+    Name: Selection
+  - Class: rviz/Tool Properties
+    Expanded:
+      - /2D Pose Estimate1
+      - /2D Nav Goal1
+      - /Publish Point1
+    Name: Tool Properties
+    Splitter Ratio: 0.5886790156364441
+  - Class: rviz/Views
+    Expanded:
+      - /Current View1
+    Name: Views
+    Splitter Ratio: 0.5
+  - Class: rviz/Time
+    Experimental: false
+    Name: Time
+    SyncMode: 0
+    SyncSource: ""
+Preferences:
+  PromptSaveOnExit: true
+Toolbars:
+  toolButtonStyle: 2
+Visualization Manager:
+  Class: ""
+  Displays:
+    - Alpha: 0.5
+      Cell Size: 1
+      Class: rviz/Grid
+      Color: 160; 160; 164
+      Enabled: true
+      Line Style:
+        Line Width: 0.029999999329447746
+        Value: Lines
+      Name: Grid
+      Normal Cell Count: 0
+      Offset:
+        X: 0
+        Y: 0
+        Z: 0
+      Plane: XY
+      Plane Cell Count: 10
+      Reference Frame: <Fixed Frame>
+      Value: true
+    - Class: rviz/Group
+      Displays:
+        - Class: rviz/TF
+          Enabled: true
+          Frame Timeout: 15
+          Frames:
+            All Enabled: false
+            imu_link:
+              Value: true
+            imu_link_ned:
+              Value: false
+            world:
+              Value: false
+          Marker Scale: 1
+          Name: TF
+          Show Arrows: false
+          Show Axes: true
+          Show Names: true
+          Tree:
+            world:
+              imu_link:
+                imu_link_ned:
+                  {}
+          Update Interval: 0
+          Value: true
+        - Acceleration properties:
+            Acc. vector alpha: 1
+            Acc. vector color: 255; 0; 0
+            Acc. vector scale: 1
+            Derotate acceleration: true
+            Enable acceleration: false
+          Axes properties:
+            Axes scale: 0.5
+            Enable axes: true
+          Box properties:
+            Box alpha: 1
+            Box color: 255; 0; 0
+            Enable box: false
+            x_scale: 1
+            y_scale: 1
+            z_scale: 1
+          Class: rviz_imu_plugin/Imu
+          Enabled: true
+          Name: Imu
+          Topic: /imu_in/data
+          Unreliable: false
+          Value: true
+          fixed_frame_orientation: true
+      Enabled: true
+      Name: imu_link
+    - Class: rviz/Group
+      Displays:
+        - Class: rviz/TF
+          Enabled: true
+          Frame Timeout: 15
+          Frames:
+            All Enabled: false
+            imu_link:
+              Value: false
+            imu_link_ned:
+              Value: true
+            world:
+              Value: false
+          Marker Scale: 1
+          Name: TF
+          Show Arrows: false
+          Show Axes: true
+          Show Names: true
+          Tree:
+            world:
+              imu_link:
+                imu_link_ned:
+                  {}
+          Update Interval: 0
+          Value: true
+        - Acceleration properties:
+            Acc. vector alpha: 1
+            Acc. vector color: 255; 0; 0
+            Acc. vector scale: 1
+            Derotate acceleration: true
+            Enable acceleration: false
+          Axes properties:
+            Axes scale: 0.6000000238418579
+            Enable axes: true
+          Box properties:
+            Box alpha: 1
+            Box color: 255; 0; 0
+            Enable box: false
+            x_scale: 1
+            y_scale: 1
+            z_scale: 1
+          Class: rviz_imu_plugin/Imu
+          Enabled: true
+          Name: Imu
+          Topic: /imu_out/data
+          Unreliable: false
+          Value: true
+          fixed_frame_orientation: true
+      Enabled: true
+      Name: imu_link_ned
+    - Class: rviz/TF
+      Enabled: true
+      Frame Timeout: 15
+      Frames:
+        All Enabled: false
+        imu_link:
+          Value: false
+        imu_link_ned:
+          Value: false
+        world:
+          Value: true
+      Marker Scale: 1
+      Name: World TF
+      Show Arrows: false
+      Show Axes: true
+      Show Names: true
+      Tree:
+        world:
+          imu_link:
+            imu_link_ned:
+              {}
+      Update Interval: 0
+      Value: true
+  Enabled: true
+  Global Options:
+    Background Color: 48; 48; 48
+    Default Light: true
+    Fixed Frame: world
+    Frame Rate: 30
+  Name: root
+  Tools:
+    - Class: rviz/Interact
+      Hide Inactive Objects: true
+    - Class: rviz/MoveCamera
+    - Class: rviz/Select
+    - Class: rviz/FocusCamera
+    - Class: rviz/Measure
+    - Class: rviz/SetInitialPose
+      Theta std deviation: 0.2617993950843811
+      Topic: /initialpose
+      X std deviation: 0.5
+      Y std deviation: 0.5
+    - Class: rviz/SetGoal
+      Topic: /move_base_simple/goal
+    - Class: rviz/PublishPoint
+      Single click: true
+      Topic: /clicked_point
+  Value: true
+  Views:
+    Current:
+      Class: rviz/Orbit
+      Distance: 3.525407314300537
+      Enable Stereo Rendering:
+        Stereo Eye Separation: 0.05999999865889549
+        Stereo Focal Distance: 1
+        Swap Stereo Eyes: false
+        Value: false
+      Focal Point:
+        X: 0.41059643030166626
+        Y: 0.21670396625995636
+        Z: -0.0979209616780281
+      Focal Shape Fixed Size: true
+      Focal Shape Size: 0.05000000074505806
+      Invert Z Axis: false
+      Name: Current View
+      Near Clip Distance: 0.009999999776482582
+      Pitch: 1.024796724319458
+      Target Frame: <Fixed Frame>
+      Value: Orbit (rviz)
+      Yaw: 3.4504361152648926
+    Saved: ~
+Window Geometry:
+  Displays:
+    collapsed: false
+  Height: 846
+  Hide Left Dock: false
+  Hide Right Dock: true
+  QMainWindow State: 000000ff00000000fd0000000400000000000001560000031bfc0200000008fb0000001200530065006c0065006300740069006f006e00000001e10000009b0000005c00fffffffb0000001e0054006f006f006c002000500072006f007000650072007400690065007302000001ed000001df00000185000000a3fb000000120056006900650077007300200054006f006f02000001df000002110000018500000122fb000000200054006f006f006c002000500072006f0070006500720074006900650073003203000002880000011d000002210000017afb000000100044006900730070006c00610079007301000000160000031b000000c900fffffffb0000002000730065006c0065006300740069006f006e00200062007500660066006500720200000138000000aa0000023a00000294fb00000014005700690064006500530074006500720065006f02000000e6000000d2000003ee0000030bfb0000000c004b0069006e0065006300740200000186000001060000030c00000261000000010000010f000002b0fc0200000003fb0000001e0054006f006f006c002000500072006f00700065007200740069006500730100000041000000780000000000000000fb0000000a00560069006500770073000000003d000002b0000000a400fffffffb0000001200530065006c0065006300740069006f006e010000025a000000b200000000000000000000000200000490000000a9fc0100000001fb0000000a00560069006500770073030000004e00000080000002e10000019700000003000004f30000003efc0100000002fb0000000800540069006d00650000000000000004f3000004f300fffffffb0000000800540069006d00650100000000000004500000000000000000000003540000031b00000004000000040000000800000008fc0000000100000002000000010000000a0054006f006f006c00730000000000ffffffff0000000000000000
+  Selection:
+    collapsed: false
+  Time:
+    collapsed: false
+  Tool Properties:
+    collapsed: false
+  Views:
+    collapsed: true
+  Width: 1200
+  X: 0
+  Y: 244


### PR DESCRIPTION
Solves #8.

The previous computation was wrong. According to REP-145, IMU orientation should express attitude of the sensor frame in a world frame. imu_transformer changes the sensor frame, so it should just recompute the new attitude by transforming the old sensor frame into the new one.

I added an example launch file and rviz config to the `test` folder which you can launch to visually inspect the situation.

I also added a unit test that fails with the old implementation and succeeds with the new one.

I also made one other fix not mentioned in #8 - I do not transform orientation covariance. If I get it correctly, the covariance is relative to the axes of the fixed world frame, so it should not change when using a different sensor frame - at least not in the case of a gravity-aligned IMU. I'm not sure how that would be in completely floating IMUs. But please, check my lines of thought around here. I haven't found a good definition of the exact meaning of orientation covariance, so this is my best guess. In the gravity-aligned case, I understand it so that estimating roll/pitch of an IMU is the same task with the same errors as estimating roll/pitch of base_link. Yaw would be similar even when not georeferenced - in the worst case, there would be some static offset, but that should not affect the covariance in world yaw.