### PR TITLE
Deprecate c headers

### DIFF
--- a/imu_transformer/include/imu_transformer/tf2_sensor_msgs.h
+++ b/imu_transformer/include/imu_transformer/tf2_sensor_msgs.h
@@ -32,7 +32,7 @@
 #ifndef TF2_SENSOR_MSGS_H
 #define TF2_SENSOR_MSGS_H
 
-#include <tf2/convert.h>
+#include <tf2/convert.hpp>
 #include <sensor_msgs/msg/imu.hpp>
 #include <sensor_msgs/msg/magnetic_field.hpp>
 #include <Eigen/Eigen>

--- a/imu_transformer/test/test_imu_transforms.cpp
+++ b/imu_transformer/test/test_imu_transforms.cpp
@@ -1,6 +1,6 @@
 /**
  * \file
- * \brief
+ * \brief 
  * \author Martin Pecka
  * SPDX-License-Identifier: BSD-3-Clause
  * SPDX-FileCopyrightText: Czech Technical University in Prague

--- a/imu_transformer/test/test_imu_transforms.cpp
+++ b/imu_transformer/test/test_imu_transforms.cpp
@@ -1,6 +1,6 @@
 /**
  * \file
- * \brief 
+ * \brief
  * \author Martin Pecka
  * SPDX-License-Identifier: BSD-3-Clause
  * SPDX-FileCopyrightText: Czech Technical University in Prague
@@ -9,7 +9,7 @@
 #include "gtest/gtest.h"
 
 
-#include <tf2/LinearMath/Quaternion.h>
+#include <tf2/LinearMath/Quaternion.hpp>
 #include <tf2_geometry_msgs/tf2_geometry_msgs.hpp>
 
 #include <Eigen/Eigen>


### PR DESCRIPTION
Related to this [pull request](https://github.com/ros2/geometry2/pull/720) in `geometry2` in which we deprecated the `.h` style headers in favor of `.hpp`.