### PR TITLE
[kilted] Update deprecated call to ament_target_dependencies

### DIFF
--- a/imu_processors/CMakeLists.txt
+++ b/imu_processors/CMakeLists.txt
@@ -22,9 +22,11 @@ add_library(imu_integrator SHARED
   src/imu_integrator.cpp
 )
 target_link_libraries(imu_integrator PUBLIC
-  rclcpp
-  rclcpp_components
-  sensor_msgs
+  ${sensor_msgs_TARGETS}
+  rclcpp::rclcpp
+  rclcpp_components::component
+  rclcpp_components::component_manager
+  sensor_msgs::sensor_msgs_library
 )
 rclcpp_components_register_node(imu_integrator
   PLUGIN "imu_processors::ImuIntegrator"
@@ -35,11 +37,13 @@ add_library(imu_bias_remover SHARED
   src/imu_bias_remover.cpp
 )
 target_link_libraries(imu_bias_remover PUBLIC
-  geometry_msgs
-  nav_msgs
-  rclcpp
-  rclcpp_components
-  sensor_msgs
+  ${geometry_msgs_TARGETS}
+  ${nav_msgs_TARGETS}
+  ${sensor_msgs_TARGETS}
+  rclcpp::rclcpp
+  rclcpp_components::component
+  rclcpp_components::component_manager
+  sensor_msgs::sensor_msgs_library
 )
 rclcpp_components_register_node(imu_bias_remover
   PLUGIN "imu_processors::ImuBiasRemover"

--- a/imu_processors/CMakeLists.txt
+++ b/imu_processors/CMakeLists.txt
@@ -21,7 +21,7 @@ find_package(tf2_ros REQUIRED)
 add_library(imu_integrator SHARED
   src/imu_integrator.cpp
 )
-ament_target_dependencies(imu_integrator
+target_link_libraries(imu_integrator PUBLIC
   rclcpp
   rclcpp_components
   sensor_msgs
@@ -34,7 +34,7 @@ rclcpp_components_register_node(imu_integrator
 add_library(imu_bias_remover SHARED
   src/imu_bias_remover.cpp
 )
-ament_target_dependencies(imu_bias_remover
+target_link_libraries(imu_bias_remover PUBLIC
   geometry_msgs
   nav_msgs
   rclcpp

--- a/imu_transformer/CMakeLists.txt
+++ b/imu_transformer/CMakeLists.txt
@@ -27,12 +27,14 @@ add_library(imu_transformer SHARED
   src/imu_transformer.cpp
 )
 target_link_libraries(imu_transformer PUBLIC
-  message_filters
-  rclcpp
-  rclcpp_components
-  sensor_msgs
-  tf2_ros
-  tf2_sensor_msgs
+  ${sensor_msgs_TARGETS}
+  message_filters::message_filters
+  rclcpp::rclcpp
+  rclcpp_components::component
+  rclcpp_components::component_manager
+  sensor_msgs::sensor_msgs_library
+  tf2_ros::tf2_ros
+  tf2_sensor_msgs::tf2_sensor_msgs
 )
 rclcpp_components_register_node(imu_transformer
   PLUGIN "imu_transformer::ImuTransformer"
@@ -45,7 +47,7 @@ if(BUILD_TESTING)
   find_package(ament_cmake_gtest REQUIRED)
 
   ament_add_gtest(test_imu_transforms test/test_imu_transforms.cpp)
-  ament_target_dependencies(test_imu_transforms sensor_msgs geometry_msgs tf2 tf2_ros tf2_sensor_msgs tf2_geometry_msgs)
+  target_link_libraries(test_imu_transforms ${geometry_msgs_TARGETS} ${sensor_msgs_TARGETS} sensor_msgs::sensor_msgs_library tf2::tf2 tf2_geometry_msgs::tf2_geometry_msgs tf2_ros::tf2_ros tf2_sensor_msgs::tf2_sensor_msgs)
 endif()
 
 install(

--- a/imu_transformer/CMakeLists.txt
+++ b/imu_transformer/CMakeLists.txt
@@ -26,7 +26,7 @@ include_directories(
 add_library(imu_transformer SHARED
   src/imu_transformer.cpp
 )
-ament_target_dependencies(imu_transformer
+target_link_libraries(imu_transformer PUBLIC
   message_filters
   rclcpp
   rclcpp_components


### PR DESCRIPTION
As of the ROS 2 Kilted release [`ament_target_dependencies` is deprecated.](https://docs.ros.org/en/kilted/Releases/Release-Kilted-Kaiju.html#ament-target-dependencies-is-deprecated)

This PR updates the syntax. Caution should be used to ensure that the target branch is not used for other ROS 2 distros.

Note: This PR was generated by a bot script, but using the simple pattern matching of the [`ros_glint`](https://github.com/MetroRobots/ros_glint) library. No LLMs were used.
