### PR TITLE
refactor: rename IMU bias remover output topic - jazzy

### DIFF
--- a/imu_processors/CMakeLists.txt
+++ b/imu_processors/CMakeLists.txt
@@ -18,10 +18,10 @@ find_package(rclcpp_components REQUIRED)
 find_package(sensor_msgs REQUIRED)
 find_package(tf2_ros REQUIRED)
 
-if("$ENV{ROS_DISTRO}" STREQUAL "humble")
-    add_compile_definitions(IS_ROS2_HUMBLE)
-elseif("$ENV{ROS_DISTRO}" STREQUAL "jazzy")
-    add_compile_definitions(IS_ROS2_JAZZY)
+# Check for Matched Event Callback support (added in rclcpp 20.0.0)
+# Humble is ~16.x, Jazzy is ~28.x
+if(rclcpp_VERSION VERSION_GREATER_EQUAL 20.0.0)
+    add_compile_definitions(RCLCPP_HAS_MATCHED_EVENT_CALLBACK)
 endif()
 
 add_library(imu_integrator SHARED

--- a/imu_processors/CMakeLists.txt
+++ b/imu_processors/CMakeLists.txt
@@ -18,6 +18,12 @@ find_package(rclcpp_components REQUIRED)
 find_package(sensor_msgs REQUIRED)
 find_package(tf2_ros REQUIRED)
 
+if("$ENV{ROS_DISTRO}" STREQUAL "humble")
+    add_compile_definitions(IS_ROS2_HUMBLE)
+elseif("$ENV{ROS_DISTRO}" STREQUAL "jazzy")
+    add_compile_definitions(IS_ROS2_JAZZY)
+endif()
+
 add_library(imu_integrator SHARED
   src/imu_integrator.cpp
 )

--- a/imu_processors/src/imu_bias_remover.cpp
+++ b/imu_processors/src/imu_bias_remover.cpp
@@ -104,8 +104,8 @@ public:
     imu_sub_ = this->create_subscription<sensor_msgs::msg::Imu>(
       "imu", rclcpp::SystemDefaultsQoS(),
       std::bind(&ImuBiasRemover::imu_callback, this, std::placeholders::_1));
-    
-    RCLCPP_WARN(this->get_logger(), 
+
+    RCLCPP_WARN(this->get_logger(),
     "\nThe following topic has been renamed:\n"
     " - Output: '/imu_biased' -> '/imu_unbiased'\n"
     "Please update your launch files or remapping rules."
@@ -130,10 +130,12 @@ private:
 
   void cmd_vel_stamped_callback(const geometry_msgs::msg::TwistStamped::ConstSharedPtr & msg)
   {
-    if (
-      abslt(msg->twist.linear.x, cmd_vel_threshold_) && abslt(msg->twist.linear.y, cmd_vel_threshold_) &&
-      abslt(msg->twist.linear.z, cmd_vel_threshold_) && abslt(msg->twist.angular.x, cmd_vel_threshold_) &&
-      abslt(msg->twist.angular.y, cmd_vel_threshold_) && abslt(msg->twist.angular.z, cmd_vel_threshold_)) {
+    if (abslt(msg->twist.linear.x, cmd_vel_threshold_) &&
+      abslt(msg->twist.linear.y, cmd_vel_threshold_) &&
+      abslt(msg->twist.linear.z, cmd_vel_threshold_) &&
+      abslt(msg->twist.angular.x, cmd_vel_threshold_) &&
+      abslt(msg->twist.angular.y, cmd_vel_threshold_) &&
+      abslt(msg->twist.angular.z, cmd_vel_threshold_)) {
       twist_is_zero_ = true;
       return;
     }

--- a/imu_processors/src/imu_bias_remover.cpp
+++ b/imu_processors/src/imu_bias_remover.cpp
@@ -105,12 +105,29 @@ public:
       "imu", rclcpp::SystemDefaultsQoS(),
       std::bind(&ImuBiasRemover::imu_callback, this, std::placeholders::_1));
 
-    // Legacy output (Ghost)
-    legacy_pub_ = this->create_publisher<sensor_msgs::msg::Imu>("imu_biased", 10);
+    #ifdef IS_ROS2_JAZZY
+      // JAZZY+ VERSION: Use the Matched Callback
+      rclcpp::PublisherOptions options;
+      options.event_callbacks.matched_callback = [this](rclcpp::MatchedInfo & info) {
+        if (info.current_count > 0 || info.intra_process_current_count > 0) {
+          RCLCPP_ERROR(this->get_logger(), "Legacy sub detected on 'imu_biased'!");
+        }
+      };
+      legacy_pub_ = this->create_publisher<sensor_msgs::msg::Imu>("imu_biased", 10, options);
 
-    // Create a timer that calls check_legacy_subscribers every 5 seconds
-    legacy_check_timer_ = this->create_wall_timer(
-    std::chrono::seconds(5), std::bind(&ImuBiasRemover::check_legacy_subscribers, this));
+    #else
+      // HUMBLE VERSION: Use the Timer
+      legacy_pub_ = this->create_publisher<sensor_msgs::msg::Imu>("imu_biased", 10);
+      legacy_timer_ = this->create_wall_timer(
+        std::chrono::seconds(5),
+        [this]() {
+          auto total = legacy_pub_->get_subscription_count() + 
+                      legacy_pub_->get_intra_process_subscription_count();
+          if (total > 0) {
+            RCLCPP_ERROR(this->get_logger(), "Legacy sub detected on 'imu_biased'!");
+          }
+        });
+    #endif
   }
 
 private:
@@ -188,20 +205,6 @@ private:
     bias_pub_->publish(bias);
   }
 
-  void check_legacy_subscribers()
-  {
-    // Sum up both types of connections
-    size_t total_subs = legacy_pub_->get_subscription_count() +
-                        legacy_pub_->get_intra_process_subscription_count();
-
-    if (total_subs > 0)
-    {
-      RCLCPP_ERROR(this->get_logger(),
-        "LEGACY SUBSCRIBER DETECTED: One or more nodes are subscribed to 'imu_biased'. "
-        "This topic is DEPRECATED and publishes no data. Please switch to 'imu_unbiased'.");
-    }
-  }
-
 private:
   bool twist_is_zero_;
   bool odom_is_zero_;
@@ -225,7 +228,7 @@ private:
   rclcpp::Subscription<sensor_msgs::msg::Imu>::SharedPtr imu_sub_;
 
   // Timer for legacy checking
-  rclcpp::TimerBase::SharedPtr legacy_check_timer_;
+  rclcpp::TimerBase::SharedPtr legacy_timer_;
 };
 
 }  // namespace imu_processors

--- a/imu_processors/src/imu_bias_remover.cpp
+++ b/imu_processors/src/imu_bias_remover.cpp
@@ -110,7 +110,9 @@ public:
       rclcpp::PublisherOptions options;
       options.event_callbacks.matched_callback = [this](rclcpp::MatchedInfo & info) {
         if (info.current_count > 0 || info.intra_process_current_count > 0) {
-          RCLCPP_ERROR(this->get_logger(), "Legacy sub detected on 'imu_biased'!");
+          RCLCPP_ERROR(this->get_logger(),
+            "LEGACY SUBSCRIBER DETECTED: One or more nodes are subscribed to 'imu_biased'. "
+            "This topic is DEPRECATED and publishes no data. Please switch to 'imu_unbiased'.");
         }
       };
       legacy_pub_ = this->create_publisher<sensor_msgs::msg::Imu>("imu_biased", 10, options);
@@ -121,10 +123,12 @@ public:
       legacy_timer_ = this->create_wall_timer(
         std::chrono::seconds(5),
         [this]() {
-          auto total = legacy_pub_->get_subscription_count() + 
+          auto total = legacy_pub_->get_subscription_count() +
                       legacy_pub_->get_intra_process_subscription_count();
           if (total > 0) {
-            RCLCPP_ERROR(this->get_logger(), "Legacy sub detected on 'imu_biased'!");
+            RCLCPP_ERROR(this->get_logger(),
+            "LEGACY SUBSCRIBER DETECTED: One or more nodes are subscribed to 'imu_biased'. "
+            "This topic is DEPRECATED and publishes no data. Please switch to 'imu_unbiased'.");
           }
         });
     #endif

--- a/imu_processors/src/imu_bias_remover.cpp
+++ b/imu_processors/src/imu_bias_remover.cpp
@@ -97,13 +97,19 @@ public:
     odom_threshold_ = this->declare_parameter<double>("odom_threshold", 0.001);
 
     // Create publisher
-    pub_ = this->create_publisher<sensor_msgs::msg::Imu>("imu_biased", 10);
+    pub_ = this->create_publisher<sensor_msgs::msg::Imu>("imu_unbiased", 10);
     bias_pub_ = this->create_publisher<geometry_msgs::msg::Vector3Stamped>("bias", 10);
 
     // Imu Subscriber
     imu_sub_ = this->create_subscription<sensor_msgs::msg::Imu>(
       "imu", rclcpp::SystemDefaultsQoS(),
       std::bind(&ImuBiasRemover::imu_callback, this, std::placeholders::_1));
+    
+    RCLCPP_WARN(this->get_logger(), 
+    "\nThe following topic has been renamed:\n"
+    " - Output: '/imu_biased' -> '/imu_unbiased'\n"
+    "Please update your launch files or remapping rules."
+    );
   }
 
 private:

--- a/imu_processors/src/imu_bias_remover.cpp
+++ b/imu_processors/src/imu_bias_remover.cpp
@@ -105,11 +105,12 @@ public:
       "imu", rclcpp::SystemDefaultsQoS(),
       std::bind(&ImuBiasRemover::imu_callback, this, std::placeholders::_1));
 
-    RCLCPP_WARN(this->get_logger(),
-    "\nThe following topic has been renamed:\n"
-    " - Output: '/imu_biased' -> '/imu_unbiased'\n"
-    "Please update your launch files or remapping rules."
-    );
+    // Legacy output (Ghost)
+    legacy_pub_ = this->create_publisher<sensor_msgs::msg::Imu>("imu_biased", 10);
+
+    // Create a timer that calls check_legacy_subscribers every 5 seconds
+    legacy_check_timer_ = this->create_wall_timer(
+    std::chrono::seconds(5), std::bind(&ImuBiasRemover::check_legacy_subscribers, this));
   }
 
 private:
@@ -187,6 +188,16 @@ private:
     bias_pub_->publish(bias);
   }
 
+  void check_legacy_subscribers()
+  {
+    if (legacy_pub_->get_subscription_count() > 0)
+    {
+      RCLCPP_ERROR(this->get_logger(),
+        "LEGACY SUBSCRIBER DETECTED: One or more nodes are subscribed to 'imu_biased'. "
+        "This topic is DEPRECATED and receives no data. Please switch to 'imu_unbiased'.");
+    }
+  }
+
 private:
   bool twist_is_zero_;
   bool odom_is_zero_;
@@ -202,12 +213,15 @@ private:
   geometry_msgs::msg::Vector3 accumulator_;
   double alpha_;
 
-  rclcpp::Publisher<sensor_msgs::msg::Imu>::SharedPtr pub_;
+  rclcpp::Publisher<sensor_msgs::msg::Imu>::SharedPtr pub_, legacy_pub_;
   rclcpp::Publisher<geometry_msgs::msg::Vector3Stamped>::SharedPtr bias_pub_;
   rclcpp::Subscription<geometry_msgs::msg::Twist>::SharedPtr cmd_sub_;
   rclcpp::Subscription<geometry_msgs::msg::TwistStamped>::SharedPtr cmd_stamped_sub_;
   rclcpp::Subscription<nav_msgs::msg::Odometry>::SharedPtr odom_sub_;
   rclcpp::Subscription<sensor_msgs::msg::Imu>::SharedPtr imu_sub_;
+
+  // Timer for legacy checking
+  rclcpp::TimerBase::SharedPtr legacy_check_timer_;
 };
 
 }  // namespace imu_processors

--- a/imu_processors/src/imu_bias_remover.cpp
+++ b/imu_processors/src/imu_bias_remover.cpp
@@ -105,17 +105,17 @@ public:
       "imu", rclcpp::SystemDefaultsQoS(),
       std::bind(&ImuBiasRemover::imu_callback, this, std::placeholders::_1));
 
-    #ifdef IS_ROS2_JAZZY
+    #ifdef RCLCPP_HAS_MATCHED_EVENT_CALLBACK
       // JAZZY+ VERSION: Use the Matched Callback
-      rclcpp::PublisherOptions options;
-      options.event_callbacks.matched_callback = [this](rclcpp::MatchedInfo & info) {
-        if (info.current_count > 0 || info.intra_process_current_count > 0) {
+      rclcpp::PublisherOptions pub_options;
+      pub_options.event_callbacks.matched_callback = [this](rclcpp::MatchedInfo & info) {
+        if (info.current_count > 0) {
           RCLCPP_ERROR(this->get_logger(),
             "LEGACY SUBSCRIBER DETECTED: One or more nodes are subscribed to 'imu_biased'. "
             "This topic is DEPRECATED and publishes no data. Please switch to 'imu_unbiased'.");
         }
       };
-      legacy_pub_ = this->create_publisher<sensor_msgs::msg::Imu>("imu_biased", 10, options);
+      legacy_pub_ = this->create_publisher<sensor_msgs::msg::Imu>("imu_biased", 10, pub_options);
 
     #else
       // HUMBLE VERSION: Use the Timer

--- a/imu_processors/src/imu_bias_remover.cpp
+++ b/imu_processors/src/imu_bias_remover.cpp
@@ -190,11 +190,15 @@ private:
 
   void check_legacy_subscribers()
   {
-    if (legacy_pub_->get_subscription_count() > 0)
+    // Sum up both types of connections
+    size_t total_subs = legacy_pub_->get_subscription_count() +
+                        legacy_pub_->get_intra_process_subscription_count();
+
+    if (total_subs > 0)
     {
       RCLCPP_ERROR(this->get_logger(),
         "LEGACY SUBSCRIBER DETECTED: One or more nodes are subscribed to 'imu_biased'. "
-        "This topic is DEPRECATED and receives no data. Please switch to 'imu_unbiased'.");
+        "This topic is DEPRECATED and publishes no data. Please switch to 'imu_unbiased'.");
     }
   }
 

--- a/imu_processors/src/imu_bias_remover.cpp
+++ b/imu_processors/src/imu_bias_remover.cpp
@@ -105,6 +105,7 @@ public:
       "imu", rclcpp::SystemDefaultsQoS(),
       std::bind(&ImuBiasRemover::imu_callback, this, std::placeholders::_1));
 
+    // Check for legacy topic subscribers
     #ifdef RCLCPP_HAS_MATCHED_EVENT_CALLBACK
       // JAZZY+ VERSION: Use the Matched Callback
       rclcpp::PublisherOptions pub_options;


### PR DESCRIPTION
**Summary:**

Renamed the output topic of the node imu_bias_remover_node from imu_biased to imu_unbiased. The previous name was misleading as the node's purpose is to publish corrected (unbiased) data, as mentioned by @peci1 


**Changes:**

   -  Topic Rename: Default output changed from '/imu_biased' to '/imu_unbiased'
   -  User Alert: Added RCLCPP_ERROR when nodes are suscribed to the old topic
  

**Verification:**

   - Verified via ros2 topic list.
   - Confirmed the warning message triggers when suscribed to the old topic in humble and jazzy
   
Closes #36